### PR TITLE
Using BrowserWorker binding for connect request

### DIFF
--- a/src/common/BrowserWorker.ts
+++ b/src/common/BrowserWorker.ts
@@ -1,0 +1,3 @@
+export interface BrowserWorker {
+  fetch: typeof fetch;
+}

--- a/src/common/WorkersWebSocketTransport.ts
+++ b/src/common/WorkersWebSocketTransport.ts
@@ -1,5 +1,6 @@
 import {ConnectionTransport} from './ConnectionTransport.js';
 import {messageToChunks, chunksToMessage} from './chunking.js';
+import {BrowserWorker} from './BrowserWorker.js';
 
 export class WorkersWebSocketTransport implements ConnectionTransport {
   ws: WebSocket;
@@ -9,10 +10,11 @@ export class WorkersWebSocketTransport implements ConnectionTransport {
   onclose?: () => void;
 
   static async create(
-    url: string,
+    endpoint: BrowserWorker,
     sessionid: string
   ): Promise<WorkersWebSocketTransport> {
-    const response = await fetch(url, {
+    const path = `/v1/connectDevtools?browser_session=${sessionid}`;
+    const response = await endpoint.fetch(path, {
       headers: {Upgrade: 'websocket'},
     });
     response.webSocket!.accept();

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export * from './common/AriaQueryHandler.js';
 export * from './common/Browser.js';
 export * from './common/BrowserConnector.js';
 export * from './common/BrowserWebSocketTransport.js';
+export * from './common/BrowserWorker.js';
 export * from './common/ChromeTargetManager.js';
 export * from './common/Connection.js';
 export * from './common/ConnectionTransport.js';


### PR DESCRIPTION
Puppeteer worker internally uses 2 requests to complete handshake with remote browser: one to acquire a browser, and another one to actually connect to it. This change make sure that both requests use the BrowserWorker binding, which was previously only used by the acquire.