### PR TITLE
Fix `page.screenshot` method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudflare/puppeteer",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/puppeteer",
-      "version": "0.0.2-alpha",
+      "version": "0.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/puppeteer",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A high-level API to control headless Chrome over the DevTools Protocol for use in Workers",
   "keywords": [
     "puppeteer",

--- a/src/common/Page.ts
+++ b/src/common/Page.ts
@@ -71,6 +71,7 @@ import {
   DeferredPromise,
 } from '../util/DeferredPromise.js';
 import {WebWorker} from './WebWorker.js';
+import {Buffer} from 'node:buffer';
 
 /**
  * @public


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**What kind of change does this PR introduce?**

Bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Did you add tests for your changes?**


**If relevant, did you update the documentation?**
N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
The 0.0.4 release switched to use the `nodejs_compat` flag over `node_compat` polyfills, however it broke the `page.screenshot` method, as it was still expecting Buffer to be defined. This PR just adds an import for Buffer in that file, so that it can resolve.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No

**Other information**
