### PR TITLE
Add sessions and limits methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: 18
+          node-version: 18.18
       - name: Setup cache for Chromium binary
         uses: actions/cache@v3
         with:
@@ -58,7 +58,7 @@ jobs:
             node: 16
           - name: Linux
             machine: ubuntu-latest
-            node: 18
+            node: 18.18
           - name: macOS
             machine: macos-latest
             node: 14

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Note that the main branch in this repo is branched off of version 17.0.0 of
 the library, to match the currently deployed version of Chromium on the
 edge.
 
+More information in the [developer docs](https://developers.cloudflare.com/browser-rendering/).
+
 Original README follows...
 
 # Puppeteer

--- a/src/common/WorkersWebSocketTransport.ts
+++ b/src/common/WorkersWebSocketTransport.ts
@@ -8,6 +8,7 @@ export class WorkersWebSocketTransport implements ConnectionTransport {
   chunks: Uint8Array[] = [];
   onmessage?: (message: string) => void;
   onclose?: () => void;
+  sessionId: string;
 
   static async create(
     endpoint: BrowserWorker,
@@ -26,6 +27,7 @@ export class WorkersWebSocketTransport implements ConnectionTransport {
       return this.ws.send('ping');
     }, 1000); // TODO more investigation
     this.ws = ws;
+    this.sessionId = sessionid;
     this.ws.addEventListener('message', event => {
       this.chunks.push(new Uint8Array(event.data as ArrayBuffer));
       const message = chunksToMessage(this.chunks, sessionid);
@@ -56,5 +58,9 @@ export class WorkersWebSocketTransport implements ConnectionTransport {
     console.log('closing websocket'); // TODO remove
     clearInterval(this.pingInterval);
     this.ws.close();
+  }
+
+  toString() {
+    return this.sessionId;
   }
 }

--- a/src/common/WorkersWebSocketTransport.ts
+++ b/src/common/WorkersWebSocketTransport.ts
@@ -60,7 +60,7 @@ export class WorkersWebSocketTransport implements ConnectionTransport {
     this.ws.close();
   }
 
-  toString() {
+  toString(): string {
     return this.sessionId;
   }
 }

--- a/src/puppeteer-core.ts
+++ b/src/puppeteer-core.ts
@@ -52,7 +52,7 @@ declare global {
 }
 
 export interface LaunchOptions {
-  connectToActiveSession: boolean // connect to a randomly picked active session if available
+  connectToActiveSession: boolean; // connect to a randomly picked active session if available
 }
 
 export interface AcquireResponse {
@@ -64,8 +64,8 @@ export interface ActiveSession {
   startTime: number; // timestamp
   // connection info, if present means there's a connection established
   // from a worker to that session
-  connectionId?: string
-  connectionStartTime?: string
+  connectionId?: string;
+  connectionStartTime?: string;
 }
 
 export interface ClosedSession extends ActiveSession {
@@ -75,7 +75,7 @@ export interface ClosedSession extends ActiveSession {
 }
 
 export interface SessionsResponse {
-  sessions: ActiveSession[]
+  sessions: ActiveSession[];
 }
 
 export interface HistoryResponse {
@@ -84,13 +84,12 @@ export interface HistoryResponse {
 
 export interface LimitsResponse {
   activeSessions: {
-    sessionId: string
-  }
-  maxConcurrentSessions: number
-  allowedBrowserAcquisitions: number // 1 if allowed, 0 otherwise
-  timeUntilNextAllowedBrowserAcquisition: number
+    sessionId: string;
+  };
+  maxConcurrentSessions: number;
+  allowedBrowserAcquisitions: number; // 1 if allowed, 0 otherwise
+  timeUntilNextAllowedBrowserAcquisition: number;
 }
-
 
 class PuppeteerWorkers extends Puppeteer {
   public constructor() {
@@ -117,12 +116,15 @@ class PuppeteerWorkers extends Puppeteer {
    * @param opts - launch options
    * @returns List of active sessions
    */
-  public async launch(endpoint: BrowserWorker, opts?: LaunchOptions): Promise<Browser> {
+  public async launch(
+    endpoint: BrowserWorker,
+    opts?: LaunchOptions
+  ): Promise<Browser> {
     opts = opts || {
-      connectToActiveSession: false
-    }
+      connectToActiveSession: false,
+    };
     if (opts.connectToActiveSession) {
-      return this.connectOrLaunch(endpoint)
+      return this.connectOrLaunch(endpoint);
     }
     const res = await endpoint.fetch('/v1/acquire');
     const status = res.status;
@@ -139,27 +141,34 @@ class PuppeteerWorkers extends Puppeteer {
 
   async connectOrLaunch(endpoint: BrowserWorker): Promise<Browser> {
     // Do we have any active free session
-    const sessions = await this.sessions(endpoint)
-    const sessionsIds = sessions.filter(v => !v.connectionId).map(v => v.sessionId)
+    const sessions = await this.sessions(endpoint);
+    const sessionsIds = sessions
+      .filter(v => {
+        return !v.connectionId;
+      })
+      .map(v => {
+        return v.sessionId;
+      });
     const launchOpts = {
-      connectToActiveSession: false
-    }
+      connectToActiveSession: false,
+    };
     if (sessionsIds) {
       // get random session
-      const sessionId = sessionsIds[Math.floor(Math.random() * sessionsIds.length)];
+      const sessionId =
+        sessionsIds[Math.floor(Math.random() * sessionsIds.length)];
       return this.connect(endpoint, sessionId!).catch(e => {
-        console.log(e)
-        return this.launch(endpoint, launchOpts)
-      })
+        console.log(e);
+        return this.launch(endpoint, launchOpts);
+      });
     }
-    return this.launch(endpoint, launchOpts)
+    return this.launch(endpoint, launchOpts);
   }
 
   /**
    * Returns active sessions
    *
-   *
-   * @remarks Sessions with a connnectionId already have a worker connection established
+   * @remarks
+   * Sessions with a connnectionId already have a worker connection established
    *
    * @param endpoint - Cloudfllare worker binding
    * @returns List of active sessions
@@ -180,7 +189,6 @@ class PuppeteerWorkers extends Puppeteer {
   /**
    * Returns recent sessions (active and closed)
    *
-   *
    * @param endpoint - Cloudfllare worker binding
    * @returns List of recent sessions (active and closed)
    */
@@ -199,7 +207,6 @@ class PuppeteerWorkers extends Puppeteer {
 
   /**
    * Returns current limits
-   *
    *
    * @param endpoint - Cloudfllare worker binding
    * @returns current limits
@@ -220,16 +227,22 @@ class PuppeteerWorkers extends Puppeteer {
   /**
    * Establish a devtools connection to an existing session
    *
-   *
    * @param endpoint - Cloudfllare worker binding
    * @param sessionId - sessionId obtained from a .sessions() call
    * @returns a browser instance
    */
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  public override async connect(endpoint: BrowserWorker, sessionId: string): Promise<Browser> {
+  public override async connect(
+    endpoint: BrowserWorker,
+    sessionId: string
+  ): Promise<Browser> {
     try {
-      const transport = await WorkersWebSocketTransport.create(endpoint, sessionId);
-      return super.connect({ transport, sessionId: sessionId });
+      const transport = await WorkersWebSocketTransport.create(
+        endpoint,
+        sessionId
+      );
+      return super.connect({transport, sessionId: sessionId});
     } catch (e) {
       throw new Error(
         `Unable to connect to existing session ${sessionId} (it may still be in use or not ready yet) - retry or launch a new browser: ${e}`

--- a/src/puppeteer-core.ts
+++ b/src/puppeteer-core.ts
@@ -51,15 +51,15 @@ declare global {
   }
 }
 
-interface LaunchOptions {
+export interface LaunchOptions {
   connectToActiveSession: boolean // connect to a randomly picked active session if available
 }
 
-interface AcquireResponse {
+export interface AcquireResponse {
   sessionId: string;
 }
 
-interface ActiveSession {
+export interface ActiveSession {
   sessionId: string;
   startTime: number; // timestamp
   // connection info, if present means there's a connection established
@@ -68,21 +68,21 @@ interface ActiveSession {
   connectionStartTime?: string
 }
 
-interface ClosedSession extends ActiveSession {
+export interface ClosedSession extends ActiveSession {
   endTime: number; // timestamp
   closeReason: number; // close reason code
   closeReasonText: string; // close reason description
 }
 
-interface SessionsResponse {
+export interface SessionsResponse {
   sessions: ActiveSession[]
 }
 
-interface HistoryResponse {
+export interface HistoryResponse {
   history: ClosedSession[];
 }
 
-interface LimitsResponse {
+export interface LimitsResponse {
   activeSessions: {
     sessionId: string
   }
@@ -102,6 +102,21 @@ class PuppeteerWorkers extends Puppeteer {
     this.limits = this.limits.bind(this);
   }
 
+  /**
+   * Launch a browser session.
+   *
+   * Optionally set it to reuse sessions automatically.
+   *
+   * @remarks
+   * If `opts.connectToActiveSession=true` it will first attempt
+   * to connect to an active session (randomly picked).
+   * If none are available, it will then attempt to launch a
+   * new session.
+   *
+   * @param endpoint - Cloudfllare worker binding
+   * @param opts - launch options
+   * @returns List of active sessions
+   */
   public async launch(endpoint: BrowserWorker, opts?: LaunchOptions): Promise<Browser> {
     opts = opts || {
       connectToActiveSession: false
@@ -122,7 +137,7 @@ class PuppeteerWorkers extends Puppeteer {
     return this.connect(endpoint, response.sessionId);
   }
 
-  public async connectOrLaunch(endpoint: BrowserWorker): Promise<Browser> {
+  async connectOrLaunch(endpoint: BrowserWorker): Promise<Browser> {
     // Do we have any active free session
     const sessions = await this.sessions(endpoint)
     const sessionsIds = sessions.filter(v => !v.connectionId).map(v => v.sessionId)
@@ -140,10 +155,16 @@ class PuppeteerWorkers extends Puppeteer {
     return this.launch(endpoint, launchOpts)
   }
 
-  // Returns active sessions
-  // Sessions with a connnectionId already have a worker connection
-  // established
-  async sessions(endpoint: BrowserWorker) {
+  /**
+   * Returns active sessions
+   *
+   *
+   * @remarks Sessions with a connnectionId already have a worker connection established
+   *
+   * @param endpoint - Cloudfllare worker binding
+   * @returns List of active sessions
+   */
+  public async sessions(endpoint: BrowserWorker) {
     const res = await endpoint.fetch('/v1/sessions');
     const status = res.status;
     const text = await res.text();
@@ -156,8 +177,14 @@ class PuppeteerWorkers extends Puppeteer {
     return data.sessions;
   }
 
-  // Returns recent sessions, active and closed
-  async history(endpoint: BrowserWorker) {
+  /**
+   * Returns recent sessions (active and closed)
+   *
+   *
+   * @param endpoint - Cloudfllare worker binding
+   * @returns List of recent sessions (active and closed)
+   */
+  public async history(endpoint: BrowserWorker) {
     const res = await endpoint.fetch('/v1/history');
     const status = res.status;
     const text = await res.text();
@@ -170,8 +197,14 @@ class PuppeteerWorkers extends Puppeteer {
     return data.history;
   }
 
-  // Returns recent sessions, active and closed
-  async limits(endpoint: BrowserWorker) {
+  /**
+   * Returns current limits
+   *
+   *
+   * @param endpoint - Cloudfllare worker binding
+   * @returns current limits
+   */
+  public async limits(endpoint: BrowserWorker) {
     const res = await endpoint.fetch('/v1/limits');
     const status = res.status;
     const text = await res.text();
@@ -184,8 +217,16 @@ class PuppeteerWorkers extends Puppeteer {
     return data;
   }
 
+  /**
+   * Establish a devtools connection to an existing session
+   *
+   *
+   * @param endpoint - Cloudfllare worker binding
+   * @param sessionId - sessionId obtained from a .sessions() call
+   * @returns a browser instance
+   */
   // @ts-ignore
-  override async connect(endpoint: BrowserWorker, sessionId: string): Promise<Browser> {
+  public override async connect(endpoint: BrowserWorker, sessionId: string): Promise<Browser> {
     try {
       const transport = await WorkersWebSocketTransport.create(endpoint, sessionId);
       return super.connect({ transport, sessionId: sessionId });
@@ -200,4 +241,4 @@ class PuppeteerWorkers extends Puppeteer {
 const puppeteer = new PuppeteerWorkers();
 export default puppeteer;
 
-export const {connect, launch} = puppeteer;
+export const {connect, launch, sessions, history, limits} = puppeteer;


### PR DESCRIPTION
Adds new methods:

- `puppeteer.sessions()`: lists current open sessions/browsers
- `puppeteer.connect(endpoint, sessionId)`: connects to an open session/browser
- `puppeteer.history()`: lists recent sessions, open and closed, useful to get a sense of what's happening
- `puppeteer.limits()`: return current limits (eg. can the user open a new browser now?)

~~Alters signature of `puppeteer.launch` to add launch options, users can omit it as was the previous behaviour:~~
~~- `puppeteer.launch(endpoint, {connectToActiveSession:true})`: automatically attempts to connect to an existing session if there is one, and if not, it launches a new browser, keeping the current behaviour. `connectToActiveSession` defaults to false.~~

`.sessions()` with `.connect(.., sessionId)` allows users to easily re-use browsers.
