### PR TITLE
Add keep alive option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
             machine: ubuntu-latest
             node: 18.18
           - name: macOS
-            machine: macos-latest
+            machine: macos-13
             node: 14
           - name: Windows
             machine: windows-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudflare/puppeteer",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/puppeteer",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/puppeteer",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A high-level API to control headless Chrome over the DevTools Protocol for use in Workers",
   "keywords": [
     "puppeteer",

--- a/src/puppeteer-core.ts
+++ b/src/puppeteer-core.ts
@@ -87,6 +87,10 @@ export interface LimitsResponse {
   timeUntilNextAllowedBrowserAcquisition: number;
 }
 
+export interface LaunchOptions {
+  keep_alive?: number; // milliseconds to keep browser alive even if it has no activity (from 10_000ms to 600_000ms, default is 60_000)
+}
+
 class PuppeteerWorkers extends Puppeteer {
   public constructor() {
     super({isPuppeteerCore: true});
@@ -103,8 +107,15 @@ class PuppeteerWorkers extends Puppeteer {
    * @param endpoint - Cloudflare worker binding
    * @returns a browser session or throws
    */
-  public async launch(endpoint: BrowserWorker): Promise<Browser> {
-    const res = await endpoint.fetch('/v1/acquire');
+  public async launch(
+    endpoint: BrowserWorker,
+    options?: LaunchOptions
+  ): Promise<Browser> {
+    let acquireUrl = '/v1/acquire';
+    if (options?.keep_alive) {
+      acquireUrl = `${acquireUrl}?keep_alive=${options.keep_alive}`;
+    }
+    const res = await endpoint.fetch(acquireUrl);
     const status = res.status;
     const text = await res.text();
     if (status !== 200) {


### PR DESCRIPTION
Add ability to set a keep alive so that users don't have to keep browser alive by "pinging" it with some devtools command. From 10 secs up to 10 minutes, defined in milliseconds.