### PR TITLE
Readd original connect method

### DIFF
--- a/src/puppeteer-core.ts
+++ b/src/puppeteer-core.ts
@@ -95,6 +95,7 @@ class PuppeteerWorkers extends Puppeteer {
   public constructor() {
     super({isPuppeteerCore: true});
     this.connect = this.connect.bind(this);
+    this.connectOriginal = this.connectOriginal.bind(this);
     this.launch = this.launch.bind(this);
     this.sessions = this.sessions.bind(this);
     this.history = this.history.bind(this);
@@ -213,9 +214,20 @@ class PuppeteerWorkers extends Puppeteer {
       );
     }
   }
+
+  /**
+   * This method attaches Puppeteer to an existing browser instance.
+   *
+   * @param options - Set of configurable options to set on the browser.
+   * @returns Promise which resolves to browser instance.
+   */
+  public async connectOriginal(options: ConnectOptions): Promise<Browser> {
+    return super.connect(options);
+  }
 }
 
 const puppeteer = new PuppeteerWorkers();
 export default puppeteer;
 
-export const {connect, launch, sessions, history, limits} = puppeteer;
+export const {connect, connectOriginal, launch, sessions, history, limits} =
+ puppeteer;


### PR DESCRIPTION
Simply add back the original connect method as `connectOriginal()`. As this repo is compatible with the Worker runtime, adding this back allows for a Worker to connect to remote browsers other than Browser Rendering API.

**What kind of change does this PR introduce?**

Add back the original connect method as `connectOriginal()

**Did you add tests for your changes?**

No. Though I have tested this manually in Worker and DO production environment.

**If relevant, did you update the documentation?**

I included JS docs to the method.

**Summary**

Adding this back allows for a Worker to connect to remote browsers other than Browser Rendering API.

**Does this PR introduce a breaking change?**

No.

**Other information**
