### PR TITLE
Allow usage of original connect method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudflare/puppeteer",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/puppeteer",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudflare/puppeteer",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "A high-level API to control headless Chrome over the DevTools Protocol for use in Workers",
   "keywords": [
     "puppeteer",

--- a/src/puppeteer-core.ts
+++ b/src/puppeteer-core.ts
@@ -17,7 +17,7 @@
 // import {initializePuppeteer} from './initializePuppeteer.js';
 import {Browser} from './common/Browser.js';
 import {BrowserWorker} from './common/BrowserWorker.js';
-import {Puppeteer} from './common/Puppeteer.js';
+import {Puppeteer, ConnectOptions} from './common/Puppeteer.js';
 import {WorkersWebSocketTransport} from './common/WorkersWebSocketTransport.js';
 
 export * from './common/NetworkConditions.js';
@@ -195,21 +195,38 @@ class PuppeteerWorkers extends Puppeteer {
    * @param sessionId - sessionId obtained from a .sessions() call
    * @returns a browser instance
    */
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
   public override async connect(
     endpoint: BrowserWorker,
     sessionId: string
+  ): Promise<Browser>;
+
+  /**
+   * Establish a devtools connection to an existing session
+   *
+   * @param options - ConnectOptions
+   * @returns a browser instance
+   */
+  public override async connect(options: ConnectOptions): Promise<Browser>;
+
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  public override async connect(
+    endpointOrOptions: BrowserWorker | ConnectOptions,
+    sessionId?: string
   ): Promise<Browser> {
+    if (!sessionId) {
+      return super.connect(endpointOrOptions as ConnectOptions);
+    }
+    const endpoint = endpointOrOptions as BrowserWorker;
     try {
       const transport = await WorkersWebSocketTransport.create(
         endpoint,
-        sessionId
+        sessionId!
       );
-      return super.connect({transport, sessionId: sessionId});
+      return super.connect({transport, sessionId: sessionId!});
     } catch (e) {
       throw new Error(
-        `Unable to connect to existing session ${sessionId} (it may still be in use or not ready yet) - retry or launch a new browser: ${e}`
+        `Unable to connect to existing session ${sessionId!} (it may still be in use or not ready yet) - retry or launch a new browser: ${e}`
       );
     }
   }

--- a/src/puppeteer-core.ts
+++ b/src/puppeteer-core.ts
@@ -221,12 +221,12 @@ class PuppeteerWorkers extends Puppeteer {
     try {
       const transport = await WorkersWebSocketTransport.create(
         endpoint,
-        sessionId!
+        sessionId
       );
-      return super.connect({transport, sessionId: sessionId!});
+      return super.connect({transport, sessionId: sessionId});
     } catch (e) {
       throw new Error(
-        `Unable to connect to existing session ${sessionId!} (it may still be in use or not ready yet) - retry or launch a new browser: ${e}`
+        `Unable to connect to existing session ${sessionId} (it may still be in use or not ready yet) - retry or launch a new browser: ${e}`
       );
     }
   }


### PR DESCRIPTION
Allows usage of original `connect`. Users can use this library in a CF worker to connect to multiple browser providers, Cloudflare or not.
