### PR TITLE
fix: incompatible fetch and Response types error while node-types version is above 20.8.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudflare/puppeteer",
-  "version": "0.0.8",
+  "version": "0.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudflare/puppeteer",
-      "version": "0.0.8",
+      "version": "0.0.11",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "4.3.4",
@@ -17,6 +17,7 @@
         "util": "0.12.5"
       },
       "devDependencies": {
+        "@cloudflare/workers-types": "^4.20240620.0",
         "@commitlint/cli": "17.0.3",
         "@commitlint/config-conventional": "17.0.3",
         "@microsoft/api-documenter": "7.19.4",
@@ -192,6 +193,12 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20240620.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20240620.0.tgz",
+      "integrity": "sha512-CQD8YS6evRob7LChvIX3gE3zYo0KVgaLDOu1SwNP1BVIS2Sa0b+FC8S1e1hhrNN8/E4chYlVN+FDAgA4KRDUEQ==",
       "dev": true
     },
     "node_modules/@commitlint/cli": {
@@ -8748,6 +8755,12 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "@cloudflare/workers-types": {
+      "version": "4.20240620.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20240620.0.tgz",
+      "integrity": "sha512-CQD8YS6evRob7LChvIX3gE3zYo0KVgaLDOu1SwNP1BVIS2Sa0b+FC8S1e1hhrNN8/E4chYlVN+FDAgA4KRDUEQ==",
       "dev": true
     },
     "@commitlint/cli": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "util": "0.12.5"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240620.0",
     "@commitlint/cli": "17.0.3",
     "@commitlint/config-conventional": "17.0.3",
     "@microsoft/api-documenter": "7.19.4",

--- a/src/common/BrowserWorker.ts
+++ b/src/common/BrowserWorker.ts
@@ -1,3 +1,5 @@
+import {type Fetcher} from '@cloudflare/workers-types';
+
 export interface BrowserWorker {
-  fetch: typeof fetch;
+  fetch: Fetcher['fetch'];
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
fix the incompatible fetch and Response types

**Did you add tests for your changes?**
no need

**If relevant, did you update the documentation?**
no need

**Summary**
upgrade node types to latest version (above v20.8.4) will cause the Response types incompatible error , becuase node-types have added undici-types as dependency after [20.8.4](https://www.npmjs.com/package/@types/node/v/20.8.4)

**Does this PR introduce a breaking change?**
no

**Other information**
![WechatIMG287](https://github.com/cloudflare/puppeteer/assets/7569533/55ef32d4-b44c-4570-9993-635af475e082)
https://github.com/cloudflare/puppeteer/issues/50#issuecomment-2156335902
