### PR TITLE
fix: handle Blob WebSocket messages for compatibility_date >= 2026-03-17

### DIFF
--- a/packages/puppeteer-cloudflare/tests/wrangler.toml
+++ b/packages/puppeteer-cloudflare/tests/wrangler.toml
@@ -2,7 +2,7 @@ name = "puppeteer-test-workers"
 main = "src/server/index.ts"
 workers_dev = false
 compatibility_flags = ["nodejs_compat"]
-compatibility_date = "2025-03-05"
+compatibility_date = "2026-04-04"
 upload_source_maps = true
 
 routes = [

--- a/packages/puppeteer-core/src/cloudflare/WorkersWebSocketTransport.ts
+++ b/packages/puppeteer-core/src/cloudflare/WorkersWebSocketTransport.ts
@@ -41,8 +41,14 @@ export class WorkersWebSocketTransport implements ConnectionTransport {
     }, 1000); // TODO more investigation
     this.ws = ws;
     this.sessionId = sessionId;
-    this.ws.addEventListener('message', event => {
-      this.chunks.push(new Uint8Array(event.data as ArrayBuffer));
+    this.ws.addEventListener('message', async event => {
+      let data: ArrayBuffer;
+      if (event.data instanceof Blob) {
+        data = await event.data.arrayBuffer();
+      } else {
+        data = event.data as ArrayBuffer;
+      }
+      this.chunks.push(new Uint8Array(data));
       const message = chunksToMessage(this.chunks, sessionId);
       if (message && this.onmessage) {
         this.onmessage!(message);


### PR DESCRIPTION
## Summary

- Fix `puppeteer.launch()` hanging indefinitely when the worker uses `compatibility_date >= 2026-03-17`
- The workerd runtime's `websocket_standard_binary_type` flag ([cloudflare/workerd#6178](https://github.com/cloudflare/workerd/pull/6178)) changed WebSocket `binaryType` default from `"arraybuffer"` to `"blob"` per the WHATWG spec
- `WorkersWebSocketTransport` assumed `event.data` was always `ArrayBuffer`; when it's a `Blob`, `new Uint8Array(blob)` silently produces invalid data, so CDP messages are never decoded
- Convert `Blob` → `ArrayBuffer` before constructing the `Uint8Array`
- Bump test suite's `compatibility_date` to `2026-04-04` so this codepath is exercised in CI

Fixes #193

## Test plan

- [x] Verified the fix works on a deployed worker with `compatibility_date = "2026-04-04"` and no `no_websocket_standard_binary_type` flag
- [ ] Existing test suite should pass with the updated `compatibility_date`