### PR TITLE
Rename Browser Rendering to Browser Run in README and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Workers version of Puppeteer Core
+# Puppeteer for Browser Run
 
 This repo is a fork of main puppeteer project. It creates a version of
-puppeteer core specialized for use in Cloudflare workers.
+puppeteer core specialized for use with Cloudflare [Browser Run](https://developers.cloudflare.com/browser-rendering/) (formerly Browser Rendering).
 
 The goals of the fork are:
 
@@ -16,10 +16,10 @@ edge.
 
 ## CDP Protocol Support
 
-[Browser Rendering now has full CDP support](https://developers.cloudflare.com/changelog/post/2026-04-10-browser-rendering-cdp-endpoint/),
+[Browser Run now has full CDP support](https://developers.cloudflare.com/changelog/post/2026-04-10-browser-rendering-cdp-endpoint/),
 so starting with `@cloudflare/puppeteer` version 1.1.0, the library uses the
 standard CDP (Chrome DevTools Protocol) internally to communicate with Browser
-Rendering.
+Run.
 
 Everything should work the same way, but if you encounter any issues, please
 [report them](https://github.com/cloudflare/puppeteer/issues). You can also

--- a/packages/puppeteer-core/package.json
+++ b/packages/puppeteer-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cloudflare/puppeteer",
   "version": "1.1.0",
-  "description": "A high-level API to control headless Chrome over the DevTools Protocol",
+  "description": "Puppeteer fork for Cloudflare Browser Run (formerly Browser Rendering)",
   "keywords": [
     "puppeteer",
     "chrome",


### PR DESCRIPTION
## Summary

Updates user-facing references from Browser Rendering to Browser Run as part of the product rename (Agents Week 2026).

### Changes
- **README.md**: Title updated to "Puppeteer for Browser Run", CDP section references updated, bridge phrasing added
- **packages/puppeteer-core/package.json**: Description field updated with bridge phrasing

Per the [rename checklist](https://wiki.cfdata.org/spaces/BRAPI/pages/1369204026/Browser+Run+Rename+Checklist).

beep-boop-🤖